### PR TITLE
Update jest dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "homepage": "https://github.com/NikhilVerma/jest-environment-node-debug-fixed#readme",
   "dependencies": {
     "devtool": "^2.3.1",
-    "jest-cli": "^19.0.1"
+    "jest": "^19.0.1"
   }
 }


### PR DESCRIPTION
Jest is the module that most projects depend on, not jest-cli. Depending on jest-cli can cause version mismatches that cause issues like #4. This closes #4.